### PR TITLE
fix: no available releases match the given constraints

### DIFF
--- a/aws/eks.tf
+++ b/aws/eks.tf
@@ -121,10 +121,10 @@ resource "aws_security_group" "eks_nodes_sg" {
 module "eks" {
   count   = var.enable_eks
   source  = "terraform-aws-modules/eks/aws"
-  version = "19.16.0"
+  version = "~> 20.31"
 
   cluster_name    = "${terraform.workspace}-${var.cluster_name}"
-  cluster_version = "1.31"
+  cluster_version = "1.33"
 
   cluster_endpoint_private_access = true # default is true
   cluster_endpoint_public_access  = true

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -1,6 +1,7 @@
 
 module "vpc" {
   source = "terraform-aws-modules/vpc/aws"
+  version = "5.21.0"
 
   name = "${terraform.workspace}-storage-vpc-sb"
   cidr = "10.0.0.0/16"

--- a/aws/provider.tf
+++ b/aws/provider.tf
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
-      version = "5.80.0"
+      version = "5.95.0"
     }
   }
 }


### PR DESCRIPTION
fixes.
```
│ Error: Failed to query available provider packages
│ 
│ Could not retrieve the list of available versions for provider hashicorp/aws: no available releases match the given constraints >= 3.72.0, >= 4.47.0, >= 4.57.0, 5.80.0, >= 6.0.0
│ 
│ To see which modules are currently depending on hashicorp/aws and what versions are specified, run the following command:
│     terraform providers
╵
```